### PR TITLE
Check package version by using >= constraint

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,6 @@ suites:
   - name: el5
     run_list:
       - recipe[chef-updater::default]
-      - recipe[git::default]
     attributes:
       chef-updater:
         package_source: "https://opscode-omnibus-packages.s3.amazonaws.com/el/5/x86_64/chef-12.5.1-1.el5.x86_64.rpm"
@@ -28,7 +27,6 @@ suites:
   - name: el6
     run_list:
       - recipe[chef-updater::default]
-      - recipe[git::default]
     attributes:
       chef-updater:
         package_source: "https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chef-12.5.1-1.el6.x86_64.rpm"
@@ -39,17 +37,15 @@ suites:
   - name: el7
     run_list:
       - recipe[chef-updater::default]
-      - recipe[git::default]
     attributes:
       chef-updater:
         package_source: "https://opscode-omnibus-packages.s3.amazonaws.com/el/7/x86_64/chef-12.5.1-1.el7.x86_64.rpm"
         package_version: "12.5.1-1"
     includes:
-      - centos.7.1
+      - centos-7.1
   - name: ubuntu
     run_list:
       - recipe[chef-updater::default]
-      - recipe[git::default]
     attributes:
       chef-updater:
         package_source: "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_12.5.1-1_amd64.deb"

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---default-path test/spec
+--default-path test/spec --color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+cache: bundler
 sudo: false
 notifications:
   slack: bloomberg-rnd:eHp3Czg42iGzaTgG8sAFeD9v

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,2 @@
 source 'https://supermarket.chef.io'
 metadata
-
-group :test, :development do
-  cookbook 'git'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ end
 group :unit do
   gem 'berkshelf'
   gem 'chefspec'
+  gem 'chef-sugar'
 end
 
 group :integration do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which provides a custom resource for updating Chef Client.'
 long_description 'Application cookbook which provides a custom resource for updating Chef Client.'
-version '1.1.1'
+version '1.1.2'
 issues_url 'https://github.com/johnbellone/chef-updater-cookbook/issues'
 source_url 'https://github.com/johnbellone/chef-updater-cookbook'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,3 +16,4 @@ supports 'ubuntu', '>= 12.04'
 supports 'fedora'
 
 depends 'poise', '~> 2.0'
+depends 'chef-sugar', '~> 3.3'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,6 +4,8 @@
 #
 # Copyright 2015, Bloomberg Finance L.P.
 #
+include_recipe 'chef-sugar::default'
+
 chef_updater node['chef-updater']['package_name'] do
   base_url node['chef-updater']['base_url']
   package_version node['chef-updater']['package_version']


### PR DESCRIPTION
Using `chef_version` DSL in found `chef-sugar` recipe to check if a later version of chef package exists when upgrading. This will avoid downgrading chef client version. For example if chef version 12.6.0 is installed on the client and the chef updater recipe is set to check for 12.5.1, then this fix will avoid downgrading chef client from version 12.6.0 to 12.5.1.
cc @johnbellone 
