### PR TITLE
IPS package handling.

### DIFF
--- a/libraries/chef_updater.rb
+++ b/libraries/chef_updater.rb
@@ -38,6 +38,9 @@ module ChefUpdaterCookbook
       # @!attribute timeout
       # @return [Integer]
       attribute(:timeout, kind_of: [String, Integer], default: 900)
+      # @!attribute use_ips_package
+      # @return [Boolean]
+      attribute(:use_ips_package, kind_of: [TrueClass, FalseClass], default: false)
 
       # @return [String]
       def remote_source
@@ -72,7 +75,11 @@ module ChefUpdaterCookbook
           "#{arch}.deb"
         elsif platform_family?('solaris2')
           arch = 'sparc' unless arch == 'i386'
-          "#{arch}.solaris"
+          if use_ips_package
+            "#{arch}.solaris.p5p"
+          else
+            "#{arch}.solaris"
+          end
         elsif platform_family?('aix')
           "#{arch}.bff"
         elsif platform_family?('windows')
@@ -107,10 +114,29 @@ module ChefUpdaterCookbook
             block { throw :end_client_run_early_due_to_chef_upgrade }
             action :nothing
           end
+
+          if platform?('solaris2') && new_resource.use_ips_package
+            # Remove it from the old packaging system if it's there
+            # Otherwise, you end up with both
+            # The solaris_package resource does not remove packages properly.
+            # https://github.com/chef/chef/blob/master/lib/chef/provider/package/solaris.rb#L59
+            # it uses pkginfo -d which tells you about the package *in a source*
+            # which is not the package *installed on the system*
+            # load_current_resource is called when you attempt to use action :remove
+            # Ergo, we do it the evil way
+            # The "yes" is necessary because pkgrm wants to be interactive
+            # and we haven't set up the "admin file" to make it accept -n for chef.
+            bash 'uninstall old chef' do
+              code 'yes | pkgrm chef'
+              only_if 'pkginfo -l chef'
+            end
+          end
+
           package new_resource.package_name do
             action :upgrade
             provider Chef::Provider::Package::Dpkg if platform?('ubuntu')
-            provider Chef::Provider::Package::Solaris if platform?('solaris2')
+            provider Chef::Provider::Package::Ips if platform?('solaris2') && new_resource.use_ips_package
+            provider Chef::Provider::Package::Solaris if platform?('solaris2') && !new_resource.use_ips_package
             source location.path
             version new_resource.package_version
             timeout new_resource.timeout

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,6 +12,7 @@ at_compile_time do
     package_version node['chef-updater']['package_version']
     package_checksum node['chef-updater']['package_checksum']
     package_source node['chef-updater']['package_source']
+    use_ips_package node['chef-updater']['use_ips_package']
     timeout node['chef-updater']['timeout'] if node['chef-updater']['timeout']
   end
 end


### PR DESCRIPTION
This not only makes the Chef Updater cookbook capable of handling IPS
packages, it correctly handles upgrading from the pre-IPS package format
as well as works around a bug in the "solaris_package" resource which
necessitates using the shell script mechanism for removing the prior
version of the package.

Please do not merge this until we know exactly what the exact package name from Chef is going to look like, since it might be "#{arch}.p5p" without the extra .solaris in there, or there might be other changes.
