### PR TITLE
Make fix to the fancy_path for OS version handling.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which provides a custom resource for updating Chef Client.'
 long_description 'Application cookbook which provides a custom resource for updating Chef Client.'
-version '2.0.0'
+version '2.1.0'
 issues_url 'https://github.com/johnbellone/chef-updater-cookbook/issues'
 source_url 'https://github.com/johnbellone/chef-updater-cookbook'
 


### PR DESCRIPTION
It turns out that Chef's handling of this is absolutely bizarre.

Upstream, the URL path is the same for all versions, so it doesn't matter; except that the version number gets inserted.

A mirror such as ours, however, may have different URL paths for it, resulting in the need to do this **in the caller**:

```
baseurl = if major >= 12 && minor >= 14 || major >= 13
            'http://chef.mirror.COMPANY.com/files/stable/chef/'
          else
            'http://chef.mirror.COMPANY.com/stable/'
          end
```

Not a fan of this, but it's what we need.

And then there's the absolute nightmare that is the version numbers - they're not the same everywhere. On Ubuntu it's the same as platform_version (for LTS numbers, anyway), and on Solaris it matches. On Windows it's all 2012r2 because the packages are the same everywhere. On redhat (which is 'el', not node['platform']) or AIX, it's even worse, as it varies, but only among the first digit. And of course this is implemented differently on those two platforms.

Long story short, this is ugly, but it matches the URLs as far as I can tell.